### PR TITLE
Enhance user feed with image rendering and saved items

### DIFF
--- a/UniMarket-Swift/UniMarket-Swift/Core/Services/ImageUploadService.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Core/Services/ImageUploadService.swift
@@ -47,7 +47,7 @@ struct ImageUploadService {
     }
 
     // MARK: - Upload message image
-    static func uploadMessageImage(_ image: UIImage, messageId: String) async throws -> String {
+    static func uploadMessageImage(_ image: UIImage, messageId: String, index: Int = 0) async throws -> String {
         guard let uid = Auth.auth().currentUser?.uid else {
             throw ImageUploadError.notAuthenticated
         }
@@ -56,7 +56,7 @@ struct ImageUploadService {
         }
 
         let ref = Storage.storage().reference()
-            .child("messages/\(uid)/\(messageId)/image_0.jpg")
+            .child("messages/\(uid)/\(messageId)/image_\(index).jpg")
 
         do {
             _ = try await ref.putDataAsync(imageData)

--- a/UniMarket-Swift/UniMarket-Swift/Core/Services/ProductServices.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Core/Services/ProductServices.swift
@@ -267,11 +267,14 @@ final class ProductStore: ObservableObject {
     @Published var errorMessage: String?
 
     private let service: ProductService
+    private let db = Firestore.firestore()
     private var listener: ListenerRegistration?
     private var imagePrefetcher: ImagePrefetcher?
+    private var savedProductIDs: Set<String> = []
 
     init(service: ProductService? = nil) {
         self.service = service ?? ProductService.shared
+        Task { await loadSavedItems() }
         startListening()
     }
 
@@ -311,6 +314,28 @@ final class ProductStore: ObservableObject {
     func toggleFavorite(for product: Product) {
         guard let index = products.firstIndex(where: { $0.id == product.id }) else { return }
         products[index].isFavorite.toggle()
+
+        let isSaved = products[index].isFavorite
+        if isSaved {
+            savedProductIDs.insert(product.id)
+        } else {
+            savedProductIDs.remove(product.id)
+        }
+
+        // Persist to Firestore user document
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        let ref = db.collection("users").document(uid)
+        Task {
+            do {
+                if isSaved {
+                    try await ref.updateData(["savedItems": FieldValue.arrayUnion([product.id])])
+                } else {
+                    try await ref.updateData(["savedItems": FieldValue.arrayRemove([product.id])])
+                }
+            } catch {
+                print("DEBUG ProductStore: failed to persist favorite \(error.localizedDescription)")
+            }
+        }
     }
 
     func createProduct(input: CreateProductInput) async throws -> Product {
@@ -325,6 +350,28 @@ final class ProductStore: ObservableObject {
         try await service.deleteProduct(product)
     }
 
+    // MARK: - Saved items persistence
+
+    /// Loads the current user's saved product IDs from their Firestore document.
+    func loadSavedItems() async {
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        do {
+            let doc = try await db.collection("users").document(uid).getDocument()
+            let ids = doc.data()?["savedItems"] as? [String] ?? []
+            savedProductIDs = Set(ids)
+            applySavedState()
+        } catch {
+            print("DEBUG ProductStore: failed to load saved items \(error.localizedDescription)")
+        }
+    }
+
+    /// Applies the savedProductIDs set to the in-memory products array.
+    private func applySavedState() {
+        for index in products.indices {
+            products[index].isFavorite = savedProductIDs.contains(products[index].id)
+        }
+    }
+
     private func startListening() {
         isLoading = true
         listener?.remove()
@@ -334,6 +381,7 @@ final class ProductStore: ObservableObject {
                 switch result {
                 case .success(let products):
                     self.products = products
+                    self.applySavedState()
                     self.errorMessage = nil
                     self.prefetchImages(for: products)
                 case .failure(let error):

--- a/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatInboxView.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatInboxView.swift
@@ -55,10 +55,17 @@ struct ChatInboxView: View {
                                 .foregroundStyle(AppTheme.primaryText)
 
                             if let listing = conversation.listingSnapshot {
-                                Text(listing.title)
-                                    .font(.poppinsRegular(11))
-                                    .foregroundStyle(AppTheme.accent)
-                                    .lineLimit(1)
+                                HStack(spacing: 0) {
+                                    Text(conversation.isInitiatedByCurrentUser
+                                         ? "Asking about "
+                                         : "Interested in ")
+                                        .font(.poppinsRegular(11))
+                                        .foregroundStyle(AppTheme.secondaryText)
+                                    Text(listing.title)
+                                        .font(.poppinsSemiBold(11))
+                                        .foregroundStyle(AppTheme.accent)
+                                }
+                                .lineLimit(1)
                             }
 
                             Text(conversation.lastMessageText)

--- a/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatStore.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatStore.swift
@@ -42,12 +42,18 @@ struct ChatMessage: Identifiable, Hashable {
 struct ChatConversation: Identifiable, Hashable {
     let id: String                  // Firestore document ID
     let participants: [String]      // array of UIDs
+    let initiatedBy: String         // UID of the user who started the conversation (the buyer)
     var otherParticipantName: String
     var otherParticipantAvatar: String?
     var lastMessageText: String
     var lastMessageAt: Date?
     var unreadCount: Int            // computed locally from unread messages
     var listingSnapshot: ChatMessage.ListingSnapshot?
+
+    /// True when the current user is the one who initiated this conversation (i.e. the buyer).
+    var isInitiatedByCurrentUser: Bool {
+        initiatedBy == Auth.auth().currentUser?.uid
+    }
 }
 
 // MARK: - ChatStore
@@ -75,13 +81,14 @@ final class ChatStore: ObservableObject {
         conversationListener = db.collection("conversations")
             .whereField("participants", arrayContains: uid)
             .addSnapshotListener { [weak self] snapshot, error in
-                guard let self, let snapshot else {
+                guard let snapshot else {
                     print("DEBUG ChatStore: conversation listener error \(error?.localizedDescription ?? "")")
-                    self?.isLoading = false
+                    Task { @MainActor in self?.isLoading = false }
                     return
                 }
 
-                Task {
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
                     var updated: [ChatConversation] = []
                     for doc in snapshot.documents {
                         if let conv = await self.parseConversation(doc: doc, currentUID: uid) {
@@ -139,9 +146,13 @@ final class ChatStore: ObservableObject {
         let lastMessageText = data["lastMessageText"] as? String ?? "No messages yet"
         let lastMessageAt = (data["lastMessageAt"] as? Timestamp)?.dateValue()
 
+        // Fall back to first participant for older conversations that don't have initiatedBy
+        let initiatedBy = data["initiatedBy"] as? String ?? participants.first ?? ""
+
         return ChatConversation(
             id: doc.documentID,
             participants: participants,
+            initiatedBy: initiatedBy,
             otherParticipantName: otherName,
             otherParticipantAvatar: otherAvatar,
             lastMessageText: lastMessageText,
@@ -161,18 +172,23 @@ final class ChatStore: ObservableObject {
             .collection("messages")
             .order(by: "sentAt")
             .addSnapshotListener { [weak self] snapshot, error in
-                guard let self, let snapshot else {
+                guard let snapshot else {
                     print("DEBUG ChatStore: message listener error \(error?.localizedDescription ?? "")")
                     return
                 }
 
-                let messages = snapshot.documents.compactMap { self.parseMessage(doc: $0) }
-                self.messagesByConversation[conversationID] = messages
+                // Dispatch property mutations through MainActor to ensure
+                // @Published changes reliably trigger SwiftUI view updates.
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    let messages = snapshot.documents.compactMap { self.parseMessage(doc: $0) }
+                    self.messagesByConversation[conversationID] = messages
 
-                // update unreadCount on the conversation object
-                if let idx = self.conversations.firstIndex(where: { $0.id == conversationID }) {
-                    let unread = messages.filter { !$0.isFromCurrentUser && $0.readAt == nil }.count
-                    self.conversations[idx].unreadCount = unread
+                    // update unreadCount on the conversation object
+                    if let idx = self.conversations.firstIndex(where: { $0.id == conversationID }) {
+                        let unread = messages.filter { !$0.isFromCurrentUser && $0.readAt == nil }.count
+                        self.conversations[idx].unreadCount = unread
+                    }
                 }
             }
 
@@ -188,8 +204,11 @@ final class ChatStore: ObservableObject {
 
     private func parseMessage(doc: QueryDocumentSnapshot) -> ChatMessage? {
         let data = doc.data()
-        guard let senderId = data["senderId"] as? String,
-              let sentAt = (data["sentAt"] as? Timestamp)?.dateValue() else { return nil }
+        guard let senderId = data["senderId"] as? String else { return nil }
+
+        // Use .estimate so locally-written messages (with pending server timestamps)
+        // resolve to an estimated date instead of nil — this lets sent messages render immediately.
+        let sentAt = (doc.get("sentAt", serverTimestampBehavior: .estimate) as? Timestamp)?.dateValue() ?? Date()
 
         let text = data["text"] as? String ?? ""
         let imageURLs = data["imageURLs"] as? [String] ?? []
@@ -256,6 +275,7 @@ final class ChatStore: ObservableObject {
         ]
         let data: [String: Any] = [
             "participants": [uid, sellerID],
+            "initiatedBy": uid,
             "lastMessageText": "",
             "lastMessageAt": FieldValue.serverTimestamp(),
             "listingSnapshot": listingData
@@ -277,6 +297,22 @@ final class ChatStore: ObservableObject {
 
         let msgRef = db.collection("conversations").document(conversationID)
             .collection("messages").document()
+
+        // Optimistic local update — message appears in the UI immediately.
+        let optimistic = ChatMessage(
+            id: msgRef.documentID,
+            senderId: uid,
+            text: trimmed,
+            imageURLs: [],
+            type: .text,
+            sentAt: Date(),
+            readAt: nil,
+            replyTo: replyTo,
+            listingSnapshot: nil
+        )
+        var current = messagesByConversation[conversationID] ?? []
+        current.append(optimistic)
+        messagesByConversation[conversationID] = current
 
         var msgData: [String: Any] = [
             "senderId": uid,
@@ -316,6 +352,22 @@ final class ChatStore: ObservableObject {
             .collection("messages").document()
 
         let imageURL = try await ImageUploadService.uploadMessageImage(image, messageId: msgRef.documentID)
+
+        // Optimistic local update — image message appears immediately after upload.
+        let optimistic = ChatMessage(
+            id: msgRef.documentID,
+            senderId: uid,
+            text: "",
+            imageURLs: [imageURL],
+            type: .image,
+            sentAt: Date(),
+            readAt: nil,
+            replyTo: nil,
+            listingSnapshot: nil
+        )
+        var current = messagesByConversation[conversationID] ?? []
+        current.append(optimistic)
+        messagesByConversation[conversationID] = current
 
         let msgData: [String: Any] = [
             "senderId": uid,

--- a/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatStore.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatStore.swift
@@ -342,23 +342,38 @@ final class ChatStore: ObservableObject {
     // MARK: - Send an image message
 
     func sendImageMessage(
-        image: UIImage,
+        images: [UIImage],
         in conversationID: String
     ) async throws {
         guard let uid = Auth.auth().currentUser?.uid else { throw ChatError.notAuthenticated }
+        guard !images.isEmpty else { return }
 
         // reserve message doc ID first so we can use it in the storage path
         let msgRef = db.collection("conversations").document(conversationID)
             .collection("messages").document()
 
-        let imageURL = try await ImageUploadService.uploadMessageImage(image, messageId: msgRef.documentID)
+        // upload all images concurrently
+        var uploadedURLs: [String] = []
+        try await withThrowingTaskGroup(of: (Int, String).self) { group in
+            for (index, image) in images.enumerated() {
+                group.addTask {
+                    let url = try await ImageUploadService.uploadMessageImage(image, messageId: msgRef.documentID, index: index)
+                    return (index, url)
+                }
+            }
+            var results: [(Int, String)] = []
+            for try await result in group {
+                results.append(result)
+            }
+            uploadedURLs = results.sorted(by: { $0.0 < $1.0 }).map(\.1)
+        }
 
         // Optimistic local update — image message appears immediately after upload.
         let optimistic = ChatMessage(
             id: msgRef.documentID,
             senderId: uid,
             text: "",
-            imageURLs: [imageURL],
+            imageURLs: uploadedURLs,
             type: .image,
             sentAt: Date(),
             readAt: nil,
@@ -372,15 +387,16 @@ final class ChatStore: ObservableObject {
         let msgData: [String: Any] = [
             "senderId": uid,
             "text": "",
-            "imageURLs": [imageURL],
+            "imageURLs": uploadedURLs,
             "type": "image",
             "sentAt": FieldValue.serverTimestamp(),
             "readAt": NSNull()
         ]
 
         try await msgRef.setData(msgData)
+        let label = images.count == 1 ? "📷 Image" : "📷 \(images.count) Images"
         try await db.collection("conversations").document(conversationID).updateData([
-            "lastMessageText": "📷 Image",
+            "lastMessageText": label,
             "lastMessageAt": FieldValue.serverTimestamp()
         ])
     }

--- a/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatThreadView.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatThreadView.swift
@@ -110,10 +110,17 @@ struct ChatThreadView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
 
             VStack(alignment: .leading, spacing: 1) {
-                Text(listing.title)
-                    .font(.poppinsSemiBold(12))
-                    .foregroundStyle(AppTheme.primaryText)
-                    .lineLimit(1)
+                HStack(spacing: 0) {
+                    Text(conversation?.isInitiatedByCurrentUser == true
+                         ? "Asking about "
+                         : "Interested in ")
+                        .font(.poppinsRegular(11))
+                        .foregroundStyle(AppTheme.secondaryText)
+                    Text(listing.title)
+                        .font(.poppinsSemiBold(12))
+                        .foregroundStyle(AppTheme.primaryText)
+                }
+                .lineLimit(1)
                 Text("$\(listing.price)")
                     .font(.poppinsRegular(11))
                     .foregroundStyle(AppTheme.secondaryText)
@@ -285,6 +292,15 @@ private struct MessageBubble: View {
                     ForEach(message.imageURLs, id: \.self) { urlString in
                         if let url = URL(string: urlString) {
                             KFImage(url)
+                                .placeholder {
+                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                        .fill(Color.gray.opacity(0.15))
+                                        .frame(width: 200, height: 150)
+                                        .overlay {
+                                            ProgressView()
+                                        }
+                                }
+                                .fade(duration: 0.2)
                                 .resizable()
                                 .scaledToFill()
                                 .frame(maxWidth: 220, maxHeight: 220)

--- a/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatThreadView.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatThreadView.swift
@@ -10,7 +10,8 @@ struct ChatThreadView: View {
 
     @State private var draftMessage: String = ""
     @State private var isSending = false
-    @State private var selectedPhotoItem: PhotosPickerItem? = nil
+    @State private var selectedPhotoItems: [PhotosPickerItem] = []
+    @State private var showCamera = false
     @State private var errorMessage: String? = nil
     @State private var replyingTo: ChatMessage.ReplySnapshot? = nil
 
@@ -93,9 +94,16 @@ struct ChatThreadView: View {
             chatStore.stopObservingMessages(for: conversationID)
             withAnimation { hideTabBar.wrappedValue = false }
         }
-        .onChange(of: selectedPhotoItem) {
-            guard let item = selectedPhotoItem else { return }
-            Task { await sendImage(from: item) }
+        .onChange(of: selectedPhotoItems) {
+            guard !selectedPhotoItems.isEmpty else { return }
+            let items = selectedPhotoItems
+            selectedPhotoItems = []
+            Task { await sendImages(from: items) }
+        }
+        .sheet(isPresented: $showCamera) {
+            ImagePicker(source: .camera) { image in
+                Task { await sendCameraImage(image) }
+            }
         }
     }
 
@@ -170,8 +178,16 @@ struct ChatThreadView: View {
 
     private var inputBar: some View {
         HStack(spacing: 10) {
-            PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
+            PhotosPicker(selection: $selectedPhotoItems, maxSelectionCount: 5, matching: .images) {
                 Image(systemName: "photo")
+                    .font(.system(size: 20))
+                    .foregroundStyle(AppTheme.secondaryText)
+            }
+
+            Button {
+                showCamera = true
+            } label: {
+                Image(systemName: "camera")
                     .font(.system(size: 20))
                     .foregroundStyle(AppTheme.secondaryText)
             }
@@ -228,20 +244,36 @@ struct ChatThreadView: View {
         isSending = false
     }
 
-    private func sendImage(from item: PhotosPickerItem) async {
-        guard let data = try? await item.loadTransferable(type: Data.self),
-              let image = UIImage(data: data) else { return }
+    private func sendImages(from items: [PhotosPickerItem]) async {
+        isSending = true
+        errorMessage = nil
 
+        var images: [UIImage] = []
+        for item in items {
+            if let data = try? await item.loadTransferable(type: Data.self),
+               let image = UIImage(data: data) {
+                images.append(image)
+            }
+        }
+        guard !images.isEmpty else { isSending = false; return }
+
+        do {
+            try await chatStore.sendImageMessage(images: images, in: conversationID)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isSending = false
+    }
+
+    private func sendCameraImage(_ image: UIImage) async {
         isSending = true
         errorMessage = nil
 
         do {
-            try await chatStore.sendImageMessage(image: image, in: conversationID)
+            try await chatStore.sendImageMessage(images: [image], in: conversationID)
         } catch {
             errorMessage = error.localizedDescription
         }
-
-        selectedPhotoItem = nil
         isSending = false
     }
 }

--- a/UniMarket-Swift/UniMarket-Swift/Features/Profile/Components/EcoSaysCard.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Features/Profile/Components/EcoSaysCard.swift
@@ -14,7 +14,7 @@ struct EcoSaysCard: View {
     @Environment(\.colorScheme) private var colorScheme
 
     private var imageBackground: Color {
-        AppTheme.cardBackground
+        .white
     }
 
     private var displayMessage: String {

--- a/UniMarket-Swift/UniMarket-Swift/Features/Search/SearchViewModel.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Features/Search/SearchViewModel.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import Combine
+import FirebaseAuth
 
 final class SearchViewModel: ObservableObject {
     enum SearchSection: String, CaseIterable, Identifiable {
@@ -147,7 +148,8 @@ final class SearchViewModel: ObservableObject {
     }
 
     func updateProducts(_ products: [Product]) {
-        self.products = products
+        let uid = Auth.auth().currentUser?.uid
+        self.products = products.filter { $0.sellerId != uid }
     }
 
     func selectTag(_ tag: String?) {


### PR DESCRIPTION
This pull request introduces several improvements and new features to the chat and product saving experiences. The most significant changes include support for sending and displaying multiple images in chat messages, enhancements to the chat UI to clarify user roles, and persistent product favorites synced with Firestore. Additionally, the codebase now ensures more reliable UI updates for chat and optimistically displays sent messages.

**Chat Functionality Improvements:**

* Added support for sending multiple images in a single chat message, including concurrent upload and immediate optimistic UI updates. The `sendImageMessage` method now accepts an array of images, and the UI allows selecting up to 5 images or taking a photo with the camera. [[1]](diffhunk://#diff-6463ce59dfb94f7aa708aabb4829f593e520109918a559fd3d7f510f8c4c5ed9L166-R194) [[2]](diffhunk://#diff-6463ce59dfb94f7aa708aabb4829f593e520109918a559fd3d7f510f8c4c5ed9L224-R276) [[3]](diffhunk://#diff-f84e48d63ef16f29f771c579004dd62bb39c1fe24a020f046e2181cf8879b213L50-R50) [[4]](diffhunk://#diff-f84e48d63ef16f29f771c579004dd62bb39c1fe24a020f046e2181cf8879b213L59-R59) [[5]](diffhunk://#diff-a5e0eecb01b4adf7bb3a3585c5e5acbaede498b4f15b04981734b0bd10fd9725L309-R399)
* Improved chat UI to indicate whether the current user is the buyer or seller in both the inbox and thread views, using the new `isInitiatedByCurrentUser` property on `ChatConversation`. [[1]](diffhunk://#diff-065273c03ce400ca23d9dbfe7024c8dd8221d2db8e8dd9ae52c88cf08886bcafL58-R67) [[2]](diffhunk://#diff-6463ce59dfb94f7aa708aabb4829f593e520109918a559fd3d7f510f8c4c5ed9R121-R130) [[3]](diffhunk://#diff-a5e0eecb01b4adf7bb3a3585c5e5acbaede498b4f15b04981734b0bd10fd9725R45-R56) [[4]](diffhunk://#diff-a5e0eecb01b4adf7bb3a3585c5e5acbaede498b4f15b04981734b0bd10fd9725R149-R155)
* Added optimistic local updates for both text and image messages, so messages appear in the UI immediately after sending. [[1]](diffhunk://#diff-a5e0eecb01b4adf7bb3a3585c5e5acbaede498b4f15b04981734b0bd10fd9725R301-R316) [[2]](diffhunk://#diff-a5e0eecb01b4adf7bb3a3585c5e5acbaede498b4f15b04981734b0bd10fd9725L309-R399)
* Improved reliability of SwiftUI updates by dispatching property mutations through the `MainActor` in chat listeners. [[1]](diffhunk://#diff-a5e0eecb01b4adf7bb3a3585c5e5acbaede498b4f15b04981734b0bd10fd9725L78-R91) [[2]](diffhunk://#diff-a5e0eecb01b4adf7bb3a3585c5e5acbaede498b4f15b04981734b0bd10fd9725L164-R183)

**Product Favorites Persistence:**

* Product favorites are now persisted to and loaded from Firestore, ensuring that a user's saved items are consistent across devices and sessions. The `ProductStore` loads saved product IDs on initialization and updates Firestore when toggling favorites. [[1]](diffhunk://#diff-74b6fcdf9bf6e490842a0a613ba53685572e50e1248deb99fd8cda851b49bbcaR270-R277) [[2]](diffhunk://#diff-74b6fcdf9bf6e490842a0a613ba53685572e50e1248deb99fd8cda851b49bbcaR317-R338) [[3]](diffhunk://#diff-74b6fcdf9bf6e490842a0a613ba53685572e50e1248deb99fd8cda851b49bbcaR353-R374) [[4]](diffhunk://#diff-74b6fcdf9bf6e490842a0a613ba53685572e50e1248deb99fd8cda851b49bbcaR384)

**Other Enhancements:**

* Improved chat message parsing to use estimated timestamps for locally-written messages, ensuring immediate rendering in the UI.
* The chat conversation now records the initiating user (buyer) in the Firestore document, supporting the new UI role indicators. [[1]](diffhunk://#diff-a5e0eecb01b4adf7bb3a3585c5e5acbaede498b4f15b04981734b0bd10fd9725R278) [[2]](diffhunk://#diff-a5e0eecb01b4adf7bb3a3585c5e5acbaede498b4f15b04981734b0bd10fd9725R45-R56) [[3]](diffhunk://#diff-a5e0eecb01b4adf7bb3a3585c5e5acbaede498b4f15b04981734b0bd10fd9725R149-R155)

These changes collectively enhance the usability and reliability of chat and product features in the app, providing a more seamless and informative user experience.