### PR TITLE
Enable live viewing of incoming messages for users

### DIFF
--- a/UniMarket-Swift/UniMarket-Swift/App/RootView.swift
+++ b/UniMarket-Swift/UniMarket-Swift/App/RootView.swift
@@ -15,6 +15,7 @@ private enum AuthRoute: Hashable {
 struct RootView: View {
     @EnvironmentObject var session: SessionManager
     @EnvironmentObject private var productStore: ProductStore
+    @EnvironmentObject private var chatStore: ChatStore
     @State private var authPath: [AuthRoute] = []
 
     var body: some View {
@@ -39,10 +40,19 @@ struct RootView: View {
             .onChange(of: session.isLoggedIn) { _, loggedIn in
                 if loggedIn {
                     authPath = []
+                    // Start observing chat conversations when user logs in
+                    chatStore.startObservingConversations()
+                } else {
+                    // Stop observing when user logs out
+                    chatStore.stopObservingConversations()
                 }
             }
             .onAppear {
                 syncListingReminder(for: session.user?.uid)
+                // Start observing conversations if already logged in
+                if session.isLoggedIn {
+                    chatStore.startObservingConversations()
+                }
             }
             .onChange(of: session.user?.uid) { previousUserID, currentUserID in
                 if let previousUserID, previousUserID != currentUserID {

--- a/UniMarket-Swift/UniMarket-Swift/Core/Services/ListingReminderService.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Core/Services/ListingReminderService.swift
@@ -6,7 +6,7 @@ actor ListingReminderService {
 
     private let center = UNUserNotificationCenter.current()
     private let defaults = UserDefaults.standard
-    private let reminderInterval: TimeInterval = 60 * 60 * 24 * 7
+    private let reminderInterval: TimeInterval = 60 //* 60 * 24 * 7
 
     private init() {}
 

--- a/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatInboxView.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatInboxView.swift
@@ -19,10 +19,8 @@ struct ChatInboxView: View {
         .background(AppTheme.background)
         .navigationTitle("Inbox")
         .onAppear {
+            // Ensure listeners are active (they should already be from RootView)
             chatStore.startObservingConversations()
-        }
-        .onDisappear {
-            chatStore.stopObservingConversations()
         }
     }
 

--- a/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatStore.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Features/Chat/ChatStore.swift
@@ -99,8 +99,55 @@ final class ChatStore: ObservableObject {
                         ($0.lastMessageAt ?? .distantPast) > ($1.lastMessageAt ?? .distantPast)
                     }
                     self.isLoading = false
+                    
+                    // Start listening to all conversations for unread count updates
+                    self.startListeningToAllConversationsForUnreadCounts(uid: uid)
                 }
             }
+    }
+    
+    // MARK: - Listen to all conversations for unread counts
+    
+    private func startListeningToAllConversationsForUnreadCounts(uid: String) {
+        // For each conversation, ensure we're listening to its messages
+        // (but only if we're not already listening)
+        for conversation in conversations {
+            // Skip if we're already listening to this conversation
+            guard messageListeners[conversation.id] == nil else { continue }
+            
+            // Set up a lightweight listener just for unread count tracking
+            startObservingMessagesForUnreadCount(conversationID: conversation.id, uid: uid)
+        }
+    }
+    
+    private func startObservingMessagesForUnreadCount(conversationID: String, uid: String) {
+        // Don't set up duplicate listeners
+        guard messageListeners[conversationID] == nil else { return }
+        
+        let listener = db.collection("conversations")
+            .document(conversationID)
+            .collection("messages")
+            .order(by: "sentAt")
+            .addSnapshotListener { [weak self] snapshot, error in
+                guard let snapshot else {
+                    print("DEBUG ChatStore: unread count listener error \(error?.localizedDescription ?? "")")
+                    return
+                }
+
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    let messages = snapshot.documents.compactMap { self.parseMessage(doc: $0) }
+                    self.messagesByConversation[conversationID] = messages
+
+                    // Update unread count on the conversation object
+                    if let idx = self.conversations.firstIndex(where: { $0.id == conversationID }) {
+                        let unread = messages.filter { !$0.isFromCurrentUser && $0.readAt == nil }.count
+                        self.conversations[idx].unreadCount = unread
+                    }
+                }
+            }
+
+        messageListeners[conversationID] = listener
     }
 
     func stopObservingConversations() {
@@ -163,41 +210,23 @@ final class ChatStore: ObservableObject {
     }
 
     // MARK: - Observe messages in a thread
-
+    
+    /// This is called when the user opens a specific chat thread.
+    /// The listener is already set up by startListeningToAllConversationsForUnreadCounts,
+    /// so this method just ensures the listener exists.
     func startObservingMessages(for conversationID: String) {
+        // If listener already exists (from unread count tracking), we're good
         guard messageListeners[conversationID] == nil else { return }
-
-        let listener = db.collection("conversations")
-            .document(conversationID)
-            .collection("messages")
-            .order(by: "sentAt")
-            .addSnapshotListener { [weak self] snapshot, error in
-                guard let snapshot else {
-                    print("DEBUG ChatStore: message listener error \(error?.localizedDescription ?? "")")
-                    return
-                }
-
-                // Dispatch property mutations through MainActor to ensure
-                // @Published changes reliably trigger SwiftUI view updates.
-                Task { @MainActor [weak self] in
-                    guard let self else { return }
-                    let messages = snapshot.documents.compactMap { self.parseMessage(doc: $0) }
-                    self.messagesByConversation[conversationID] = messages
-
-                    // update unreadCount on the conversation object
-                    if let idx = self.conversations.firstIndex(where: { $0.id == conversationID }) {
-                        let unread = messages.filter { !$0.isFromCurrentUser && $0.readAt == nil }.count
-                        self.conversations[idx].unreadCount = unread
-                    }
-                }
-            }
-
-        messageListeners[conversationID] = listener
+        
+        // Otherwise set up the listener (shouldn't normally happen, but defensive)
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        startObservingMessagesForUnreadCount(conversationID: conversationID, uid: uid)
     }
 
     func stopObservingMessages(for conversationID: String) {
-        messageListeners[conversationID]?.remove()
-        messageListeners.removeValue(forKey: conversationID)
+        // Don't remove the listener when leaving a chat thread
+        // We want to keep it active for unread count tracking
+        // The listener will be removed when stopObservingConversations() is called
     }
 
     // MARK: - Parse a message document


### PR DESCRIPTION
This pull request improves the chat conversation listening logic across the app to ensure users always receive up-to-date unread message counts and conversation data. The main changes involve starting and maintaining lightweight listeners for all conversations when a user is logged in, and keeping these listeners active for accurate unread counts, even when navigating away from chat threads. Additionally, a minor change was made to the listing reminder interval for testing or debugging purposes.

**Chat conversation observation improvements:**

* The `RootView` now injects `ChatStore` as an environment object and starts or stops observing chat conversations when the user logs in or out, ensuring listeners are always correctly managed. [[1]](diffhunk://#diff-ea35ac994eb808df22e0a90114b1465aecce99c2e925a7e8d0fd11692041654cR18) [[2]](diffhunk://#diff-ea35ac994eb808df22e0a90114b1465aecce99c2e925a7e8d0fd11692041654cR43-R55)
* In `ChatStore`, a new method `startListeningToAllConversationsForUnreadCounts` is introduced to set up lightweight listeners for all conversations, tracking unread counts for each. These listeners are started when conversations are loaded and kept active until the user logs out.
* The message observation logic has been refactored so that listeners are not removed when leaving a chat thread, but only when logging out, ensuring unread counts remain accurate in the inbox and elsewhere.
* In `ChatInboxView`, the logic to stop observing conversations on view disappear has been removed, since listeners are now managed globally from `RootView`.

**Other changes:**

* The reminder interval in `ListingReminderService` has been shortened (likely for testing), from one week to one minute.