### PR TITLE
As the title says

### DIFF
--- a/UniMarket-Swift/UniMarket-Swift/Models/Product.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Models/Product.swift
@@ -88,9 +88,15 @@ struct Product: Identifiable, Hashable, Codable {
         soldAt       = try c.decodeIfPresent(Date.self, forKey: .soldAt)
         imagePath    = try c.decodeIfPresent(String.self, forKey: .imagePath)
         imageURLs    = try c.decodeIfPresent([String].self, forKey: .imageURLs) ?? []
-        status       = try c.decodeIfPresent(ProductStatus.self, forKey: .status) ?? .active
-        // Legacy docs don't have "kind" — default to .sale
-        kind         = try c.decodeIfPresent(ListingKind.self, forKey: .kind) ?? .sale
+        // Firestore writes status via `firestoreValue` (lowercase) while the
+        // enum rawValue is capitalized — decode through the case-insensitive
+        // initializer so Firestore documents don't throw on the lowercase form.
+        let statusRaw = try c.decodeIfPresent(String.self, forKey: .status)
+        status       = ProductStatus(firestoreValue: statusRaw)
+        // Legacy docs don't have "kind" — default to .sale via the
+        // case-insensitive parser.
+        let kindRaw  = try c.decodeIfPresent(String.self, forKey: .kind)
+        kind         = ListingKind(firestoreValue: kindRaw)
     }
 }
 

--- a/UniMarket-Swift/UniMarket-Swift/Services/ProductServices.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Services/ProductServices.swift
@@ -328,7 +328,8 @@ final class ProductService {
             soldAt: soldAtTimestamp?.dateValue(),
             imagePath: data["imagePath"] as? String,
             imageURLs: imageURLs,
-            status: ProductStatus(firestoreValue: data["status"] as? String)
+            status: ProductStatus(firestoreValue: data["status"] as? String),
+            kind: ListingKind(firestoreValue: data["kind"] as? String)
         )
     }
 }

--- a/UniMarket-Swift/UniMarket-Swift/ViewModels/BrowseSearchViewModel.swift
+++ b/UniMarket-Swift/UniMarket-Swift/ViewModels/BrowseSearchViewModel.swift
@@ -28,6 +28,10 @@ final class BrowseSearchViewModel: ObservableObject {
     @Published var maxPrice: Int = 0 {
         didSet { scheduleBrowseRefresh() }
     }
+    /// Filter chip — when on, only kind == .donation listings pass through.
+    @Published var showDonationsOnly: Bool = false {
+        didSet { scheduleBrowseRefresh() }
+    }
     @Published private(set) var products: [Product] = [] {
         didSet {
             if oldValue.map(\.id) != products.map(\.id) {
@@ -64,6 +68,7 @@ final class BrowseSearchViewModel: ObservableObject {
         if minRating > 0 { count += 1 }
         if minPrice != priceBounds.lowerBound || maxPrice != priceBounds.upperBound { count += 1 }
         if sortOption != .relevance { count += 1 }
+        if showDonationsOnly { count += 1 }
         return count
     }
 
@@ -108,6 +113,7 @@ final class BrowseSearchViewModel: ObservableObject {
         onlyFavorites = false
         minRating = 0
         sortOption = .relevance
+        showDonationsOnly = false
         resetPriceRange()
     }
 
@@ -129,7 +135,8 @@ final class BrowseSearchViewModel: ObservableObject {
             minRating: minRating,
             sortOption: sortOption,
             minPrice: minPrice,
-            maxPrice: maxPrice
+            maxPrice: maxPrice,
+            showDonationsOnly: showDonationsOnly
         )
 
         isSearching = true

--- a/UniMarket-Swift/UniMarket-Swift/ViewModels/ScanQRViewModel.swift
+++ b/UniMarket-Swift/UniMarket-Swift/ViewModels/ScanQRViewModel.swift
@@ -118,9 +118,30 @@ final class ScanQRViewModel: ObservableObject {
                 transactionID: payload.transactionId,
                 source: source.rawValue
             ))
+
+            // BQ#3 — donation fulfilment marker. When the QR belongs to a
+            // donation listing, emit donation_picked_up so the funnel chart
+            // can complete the donation_claimed → donation_approved → picked_up
+            // pipeline. Done as a best-effort lookup; a missing kind defaults
+            // to .sale and emits nothing extra.
+            let listingKind = await fetchListingKind(listingID: payload.listingId)
+            if listingKind == .donation {
+                analytics.track(.donationPickedUp(listingID: payload.listingId))
+            }
             scanState = .confirmed
         } catch {
             scanState = .error(error.localizedDescription)
+        }
+    }
+
+    private func fetchListingKind(listingID: String) async -> ListingKind {
+        let db = Firestore.firestore()
+        do {
+            let doc = try await db.collection("listings").document(listingID).getDocument()
+            let raw = doc.data()?["kind"] as? String
+            return ListingKind(firestoreValue: raw)
+        } catch {
+            return .sale
         }
     }
 }

--- a/UniMarket-Swift/UniMarket-Swift/ViewModels/SearchViewModel.swift
+++ b/UniMarket-Swift/UniMarket-Swift/ViewModels/SearchViewModel.swift
@@ -33,6 +33,32 @@ struct BrowseSearchSnapshot: Sendable {
     let sortOption: SearchSortOption
     let minPrice: Int
     let maxPrice: Int
+    /// When true, only listings with kind == .donation pass the filter.
+    let showDonationsOnly: Bool
+
+    init(
+        products: [Product],
+        query: String,
+        selectedTag: String?,
+        selectedConditions: Set<String>,
+        onlyFavorites: Bool,
+        minRating: Double,
+        sortOption: SearchSortOption,
+        minPrice: Int,
+        maxPrice: Int,
+        showDonationsOnly: Bool = false
+    ) {
+        self.products = products
+        self.query = query
+        self.selectedTag = selectedTag
+        self.selectedConditions = selectedConditions
+        self.onlyFavorites = onlyFavorites
+        self.minRating = minRating
+        self.sortOption = sortOption
+        self.minPrice = minPrice
+        self.maxPrice = maxPrice
+        self.showDonationsOnly = showDonationsOnly
+    }
 }
 
 enum SearchBrowseEngine {
@@ -57,8 +83,9 @@ enum SearchBrowseEngine {
             let matchesPrice = product.price >= snapshot.minPrice && product.price <= snapshot.maxPrice
             let matchesFavorite = !snapshot.onlyFavorites || product.isFavorite
             let matchesRating = product.rating >= snapshot.minRating
+            let matchesKind = !snapshot.showDonationsOnly || product.kind == .donation
 
-            return matchesQuery && matchesTag && matchesCondition && matchesPrice && matchesFavorite && matchesRating
+            return matchesQuery && matchesTag && matchesCondition && matchesPrice && matchesFavorite && matchesRating && matchesKind
         }
 
         switch snapshot.sortOption {

--- a/UniMarket-Swift/UniMarket-Swift/Views/BrowseSearchView.swift
+++ b/UniMarket-Swift/UniMarket-Swift/Views/BrowseSearchView.swift
@@ -101,6 +101,14 @@ struct BrowseSearchView: View {
                                 viewModel.selectTag(nil)
                             }
 
+                            // Donations filter chip — toggles kind=.donation only.
+                            SearchTagChip(
+                                label: "Donations",
+                                isSelected: viewModel.showDonationsOnly
+                            ) {
+                                viewModel.showDonationsOnly.toggle()
+                            }
+
                             ForEach(viewModel.availableTags, id: \.self) { tag in
                                 SearchTagChip(label: tag.capitalized, isSelected: viewModel.selectedTag == tag) {
                                     viewModel.selectTag(tag)


### PR DESCRIPTION
This pull request introduces a new "Donations only" filter to the product browsing and search experience, ensuring users can easily view only donation listings. It also improves the handling of the `kind` field throughout the app, ensuring consistent parsing and analytics tracking for donation-related actions.

**Filtering and Search Improvements:**

* Added a `showDonationsOnly` filter to `BrowseSearchViewModel` and `BrowseSearchSnapshot`, allowing users to filter listings to only those with `kind == .donation`. This filter is reset on search reset and correctly increments the active filter count. [[1]](diffhunk://#diff-f0f8c157e5c3924b51381598d5d7f877807275ddca4988692374c4e3bfed1fb0R31-R34) [[2]](diffhunk://#diff-f0f8c157e5c3924b51381598d5d7f877807275ddca4988692374c4e3bfed1fb0R71) [[3]](diffhunk://#diff-f0f8c157e5c3924b51381598d5d7f877807275ddca4988692374c4e3bfed1fb0R116) [[4]](diffhunk://#diff-f0f8c157e5c3924b51381598d5d7f877807275ddca4988692374c4e3bfed1fb0L132-R139) [[5]](diffhunk://#diff-73b9deb96de48be407505e8dde9ba4efec7f0b8c7799ed66bac8a05ce5a5ecb7R36-R61)
* Updated the search engine logic to respect the new donations-only filter, ensuring only donation listings are shown when the filter is active.
* Added a "Donations" filter chip to the browse UI, letting users toggle this filter easily.

**Product Model and Service Enhancements:**

* Improved decoding of the `status` and `kind` fields in the `Product` model to handle Firestore's lowercase strings and legacy documents, using case-insensitive initializers.
* Updated `ProductService` to always parse and provide the `kind` field from Firestore data.

**Analytics and QR Scan Tracking:**

* In `ScanQRViewModel`, added logic to detect when a scanned listing is a donation and emit a `donationPickedUp` analytics event, ensuring the donation funnel is properly tracked.